### PR TITLE
Allow generics in Signatures

### DIFF
--- a/packages/template/-private/signature.d.ts
+++ b/packages/template/-private/signature.d.ts
@@ -45,7 +45,7 @@ export type ComponentSignatureBlocks<S> = S extends { Blocks: infer Blocks }
 
 /** Given a component signature `S`, get back the `Element` type. */
 export type ComponentSignatureElement<S> = S extends { Element: infer Element }
-  ? NonNullable<Element> extends never
+  ? Element extends null
     ? unknown
     : Element
   : unknown;


### PR DESCRIPTION
Potential fix to #610

I was applying the fix as part of this PR locally on my PR tildeio/ember-element-helper#107 and see if in my type-test-component:

```ts
import Component from '@glimmer/component';
import type { ElementSignature, ElementFromTagName } from 'ember-element-helper';

interface ElementReceiverSignature<T extends string = 'article'> {
  Element: ElementFromTagName<T>;
  Args: {
    tag: ElementSignature<T>['Return'];
  };
  Blocks: {
    default: [];
  }
}

export default class ElementReceiver<T extends string> extends Component<ElementReceiverSignature<T>> {}
```

```hbs
{{#let @tag as |Tag|}}
  {{!@glint-ignore}}
  <Tag id="content" ...attributes>{{yield}}</Tag>
{{/let}}
```

I was able to remove the line `{{!@glint-ignore}}` and if the type linting still passes, which is the case.

So, yes this is a potential fix, but I share the same concerns as @dfreeman this might come with side-effects.

So I'll make it a draft PR.